### PR TITLE
Fix duplicate quiz questions on a tag

### DIFF
--- a/src/utils/questions.ts
+++ b/src/utils/questions.ts
@@ -43,7 +43,12 @@ export async function getAllQuestionsByTags(tags: Set<string>): Promise<QuizQues
         const qnasWithFilePath: QuizQuestion[] = qnas.map((qna) => convertQnaPairToQuizQuestion(noteId, note, qna))
         questions.push(...qnasWithFilePath)
     }
-    return questions
+    // Now, deduplicate the questions
+    const uniqueQuestions = new Map<string, QuizQuestion>();
+    for (const question of questions) {
+        uniqueQuestions.set(question.id ?? "", question);
+    }
+    return Array.from(uniqueQuestions.values());
 }
 
 export function convertQnaPairToQuizQuestion(noteId: string, noteFile: TFile, quizQuestion: QuestionAnswerPair): QuizQuestion {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "importHelpers": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
-    "rootDir": "src",
+    "rootDir": ".",
 	"strictNullChecks": true,
     "lib": [
       "DOM",


### PR DESCRIPTION
Suppose a note has two tags: `tag1`, `tag2`

And you make a quiz with `tag1` and `tag2` selected

Then, the quiz view will render the questions on the note twice – for each tag. This fix just deduplicates the questions generation. 